### PR TITLE
extend author field to indicate the community

### DIFF
--- a/mergedrss.php
+++ b/mergedrss.php
@@ -81,6 +81,11 @@ class MergedRSS {
 					$item->title = html_entity_decode($item->title, ENT_QUOTES,  'UTF-8');
 					$source = $item->addChild('source', '' . $feed_array[1]);
 					$source->addAttribute('url', $feed_array[2]);
+
+					$ns = $item->getNamespaces(true);
+					$dc = $item->children($ns['dc']);
+					$dc->creator = sprintf("%s (%s)", $dc->creator, $feed_array[2]);
+
 					$items[] = $item;
 				}
 			}


### PR DESCRIPTION
Hallo,
hier mein per Mail angekündigter Feature-Request.

> Das Autorenfeld im Feed wird durch die jeweilige Community erweitert, damit man die einzelnen Einträge auf einen Blick zuordnen kann.

Das letzte mal, als ich ernsthaft was mit PHP gemacht habe, war vor gefühlten 20 Jahren ~ ebenso ist XML nicht unbedingt meine Welt. Bin mir unschlüssig, ob ein reiner String nicht die Feedreader verwirrt, möglicherweise muss man noch ein bisschen nachbessern. :smile_cat: 

Würde mich sehr freuen, wenn dieses Feature Einzug findet.
